### PR TITLE
Put actual error in error.

### DIFF
--- a/src/L.Routing.Valhalla.js
+++ b/src/L.Routing.Valhalla.js
@@ -67,8 +67,8 @@
             this._routeDone(data, wps, callback, context);
           } else {
             callback.call(context || callback, {
-              status: -1,
-              message: 'HTTP request failed: ' + err
+              status: err.status,
+              message: err.responseText
             });
           }
         }


### PR DESCRIPTION
Put error message from server and status code in error, because Valhalla actually returns meaningful errors.