### PR TITLE
Demo tweaks

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -1,14 +1,14 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <meta charset="utf-8" />
+    <meta charset="utf-8">
     <title>Leaflet Valhalla Example</title>
-    <link rel="stylesheet" href="http://cdn.leafletjs.com/leaflet-0.7.3/leaflet.css" />
-    <link rel="stylesheet" href="./leaflet.routing.valhalla.css" />
+    <link rel="stylesheet" href="//cdn.leafletjs.com/leaflet-0.7.3/leaflet.css">
+    <link rel="stylesheet" href="./leaflet.routing.valhalla.css">
 </head>
 <body>
     <div id="map" class="map"></div>
-    <script src="http://cdn.leafletjs.com/leaflet-0.7.3/leaflet.js"></script>
+    <script src="//cdn.leafletjs.com/leaflet-0.7.3/leaflet.js"></script>
     <script src="https://rawgit.com/perliedman/leaflet-routing-machine/master/dist/leaflet-routing-machine.js"></script>
     <script src="https://mapzen.com/tangram/0.1/tangram.min.js"></script>
     <script src="../dist/lrm-valhalla.js"></script>

--- a/examples/index.html
+++ b/examples/index.html
@@ -7,7 +7,7 @@
     <link rel="stylesheet" href="./leaflet.routing.valhalla.css">
 </head>
 <body>
-    <div id="map" class="map"></div>
+    <div id="map"></div>
     <script src="//cdn.leafletjs.com/leaflet-0.7.3/leaflet.js"></script>
     <script src="https://rawgit.com/perliedman/leaflet-routing-machine/master/dist/leaflet-routing-machine.js"></script>
     <script src="https://mapzen.com/tangram/0.1/tangram.min.js"></script>

--- a/examples/index.js
+++ b/examples/index.js
@@ -1,26 +1,26 @@
-var map = L.map('map',{
-  inertia: false
-});
+var map = L.map('map');
 
 // Using Tangram 
 var layer = Tangram.leafletLayer({
   scene: 'scene.yaml',
-        attribution: '<a href="https://mapzen.com/tangram" target="_blank">Tangram</a> | &copy; OSM contributors | <a href="https://mapzen.com/" target="_blank">Mapzen</a>'
+  attribution: '<a href="https://mapzen.com/tangram" target="_blank">Tangram</a> | &copy; OSM contributors | <a href="https://mapzen.com/" target="_blank">Mapzen</a>'
 });
 layer.addTo(map);
 
 /*
+// You can also use normal OSM tiles instead
 L.tileLayer('http://{s}.tile.osm.org/{z}/{x}/{y}.png', {
-	attribution: '&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
+  attribution: '&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
 }).addTo(map);
 */
+
 L.Routing.control({
-	waypoints: [
-		L.latLng(57.74, 11.94),
-		L.latLng(57.6792, 11.949)
+  waypoints: [
+    L.latLng(57.74, 11.94),
+    L.latLng(57.6792, 11.949)
 	],
-  // you can get valhalla api key from Mapzen developer (https://mapzen.com/developers)
-	router: L.Routing.valhalla('my-api-key','auto'),
+  // You can get your own Valhalla API key from the Mapzen developer portal (https://mapzen.com/developers/)
+	router: L.Routing.valhalla('<my api key>', 'auto'),
   formatter: new L.Routing.Valhalla.Formatter(),
   summaryTemplate:'<div class="start">{name}</div><div class="info {transitmode}">{distance}, {time}</div>',
   routeWhileDragging: false

--- a/examples/index.js
+++ b/examples/index.js
@@ -18,9 +18,9 @@ L.Routing.control({
   waypoints: [
     L.latLng(57.74, 11.94),
     L.latLng(57.6792, 11.949)
-	],
+  ],
   // You can get your own Valhalla API key from the Mapzen developer portal (https://mapzen.com/developers/)
-	router: L.Routing.valhalla('<my api key>', 'auto'),
+  router: L.Routing.valhalla('<my api key>', 'auto'),
   formatter: new L.Routing.Valhalla.Formatter(),
   summaryTemplate:'<div class="start">{name}</div><div class="info {transitmode}">{distance}, {time}</div>',
   routeWhileDragging: false


### PR DESCRIPTION
#### index.html
- HTML5 has not required self-closing tags for years.
- External dependencies on http:// should be protocol-relative URLs

#### index.js
- Is `{inertia: false}` in the map initialization REQUIRED for Valhalla? If not, I suggest leaving it out of the example and only using default options, to keep things super simple.
- Standardize tab spacing
- Copy edit Valhalla API notice
- change `'my-api-key'` to something that reads more like a placeholder than a setting field name (borrowing from Mapbox's use of `<your access token>` in [this example](https://www.mapbox.com/mapbox.js/api/v2.2.1/api-access-tokens/)
- Clarified that commented-out OSM tiles are still a legit alternative to Tangram - I'd consider that for very simple getting-started examples that we keep to the most basic of functionalities, but show progressively enhanced examples that do other nifty things on top of it