### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,16 @@ Valhalla is a free, open-source routing service with dynamic run-time costing th
 As with the other LRM plug-ins, you can [download lrm-valhalla](https://mapzen.com/resources/lrm-valhalla-0.0.9.zip) and insert the JavaScript file into your page right after the line where it loads Leaflet Routing Machine:
 
 ```html
-[...]
+/* ... */
 <script src="leaflet-routing-machine.js"></script>
 <script src="lrm-valhalla.js"></script>
-[...]
+/* ... */
+```
+
+Also, include the stylesheet. This can replace the default `leaflet-routing-machine.css` provided by LRM, since the Valhalla plugin includes its own styles and icons.
+
+```html
+<link rel="stylesheet" href="leaflet.routing.valhalla.css">
 ```
 
 Insert your [Valhalla API key](https://mapzen.com/developers) and the routing mode (`auto`, `bicycle`, or `pedestrian`). (Note that no options are needed for `formatter`.)

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ L.Routing.control({
 }).addTo(map);
 ```
 
-See the [Valhalla API documentation](https://github.com/valhalla/valhalla-docs/blob/gh-pages/api-reference.md) for more information.
+See the [Leaflet Routing Machine documentation](http://www.liedman.net/leaflet-routing-machine/tutorials/) and  [Valhalla API documentation](https://github.com/valhalla/valhalla-docs/blob/gh-pages/api-reference.md) for more information.
 
 ## Using Valhalla with npm and Browserify
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 Leaflet Routing Machine / Valhalla by Mapzen
-=====================================
+============================================
 
 
      ██▒   █▓ ▄▄▄       ██▓     ██░ ██  ▄▄▄       ██▓     ██▓    ▄▄▄      
@@ -22,18 +22,24 @@ Valhalla is a free, open-source routing service with dynamic run-time costing th
 
 As with the other LRM plug-ins, you can [download lrm-valhalla](https://mapzen.com/resources/lrm-valhalla-0.0.9.zip) and insert the JavaScript file into your page right after the line where it loads Leaflet Routing Machine:
 
-    [...]
-    <script src="leaflet-routing-machine.js"></script>
-    <script src="lrm-valhalla.js"></script>
-    [...]
+```html
+[...]
+<script src="leaflet-routing-machine.js"></script>
+<script src="lrm-valhalla.js"></script>
+[...]
+```
 
 Insert your [Valhalla API key](https://mapzen.com/developers) and the routing mode (`auto`, `bicycle`, or `pedestrian`). (Note that no options are needed for `formatter`.)
 
-    L.Routing.control({
-      [...]
-      router: L.Routing.valhalla('my-api-key', 'auto')
-      formatter: new L.Routing.Valhalla.Formatter()
-    })
+```js
+var map = L.map('map');
+
+L.Routing.control({
+  // [...] See Valhalla API documentation for other options
+  router: L.Routing.valhalla('<my api key>', 'auto')
+  formatter: new L.Routing.Valhalla.Formatter()
+}).addTo(map);
+```
 
 See the [Valhalla API documentation](https://github.com/valhalla/valhalla-docs/blob/gh-pages/api-reference.md) for more information.
 
@@ -41,36 +47,44 @@ See the [Valhalla API documentation](https://github.com/valhalla/valhalla-docs/b
 
 Like other plug-ins, the Valhalla plug-in can be installed using npm instead of downloading the script manually:
 
-    npm install --save lrm-valhalla
+```sh
+npm install --save lrm-valhalla
+```
 
 Once the Valhalla plug-in is installed, update the router and formatter instances to tell the Leaflet Routing Machine to use Valhalla’s engine. 
 
-    var L = require('leaflet');
-    require('leaflet-routing-machine');
-    require('lrm-valhalla');
+```js
+var L = require('leaflet');
+require('leaflet-routing-machine');
+require('lrm-valhalla');
 
-    L.Routing.control({
-      router: L.Routing.valhalla('my-api-key', 'auto'),
-      formatter: new L.Routing.Valhalla.Formatter()
-    });
+var map = L.map('map');
+
+L.Routing.control({
+  router: L.Routing.valhalla('<my api key>', 'auto'),
+  formatter: new L.Routing.Valhalla.Formatter()
+}).addTo(map);
+```
 
 For `router`, insert your [Valhalla API key](https://mapzen.com/developers) and the routing mode (such as `auto`, `bicycle`, or `pedestrian`); see the [Valhalla API documentation](https://github.com/valhalla/valhalla-docs/blob/gh-pages/api-reference.md) for more information. (Note that no options are needed for `formatter`.)
 
 You can also change the routing mode after the router is created. Say you had different transportation options on your map and wanted to change `transitmode` to `bicycle` when that button is clicked: 
 
-    var rr = L.Routing.valhalla('my-api-key', 'auto');
-    [...]
-    bikeButton.onClick: function () {
-      rr.route({transitmode: "bicycle"});
-    }
+```js
+var rr = L.Routing.valhalla('<my api key>', 'auto');
+[...]
+bikeButton.onClick: function () {
+  rr.route({transitmode: "bicycle"});
+}
+```
 
 ## Running a local example
 
 If you want to run your lrm-valhalla plug-in locally for test and development purposes:
 
 - Install lrm-valhalla through npm or [download the contents of the lrm-valhalla repo](https://github.com/valhalla/lrm-valhalla/archive/master.zip)
-- get your API key from [mapzen.com/developers](https://mapzen.com/developers)
+- get your API key from [mapzen.com/developers](https://mapzen.com/developers/)
 - paste it into the example's index.js and choose the transportation mode (`auto`, `bicycle`, or `pedestrian`)
-- start a local web server (such as python -m SimpleHTTPServer or the local server you prefer)
-- go to localhost:8000/examples in your browser (all assets needed to run Valhalla are in the /examples folder)
+- start a local web server (such as `python -m SimpleHTTPServer` or the local server you prefer)
+- go to `http://localhost:8000/examples` in your browser (all assets needed to run Valhalla are in the `/examples` folder)
 


### PR DESCRIPTION
Lines 41 and 66 - `.addTo(map)` is required in real life, is there a reason why this is not in the README?

Because `map` can really mean any variable, I added in the `var map = L.map('map')` lines to indicate where it is coming from and what it is referring to. There may be better ways to do this.

Line 38 (and also elsewhere) - Is it clear what the `[...]` means? Is it necessary? Why is it used in some cases and not others? Could it be clearer as comments so that the code, when copy-pasted, will not break someone's existing code?

Others
- propose `<my api key>` as a replacement placeholder
- use syntax highlighting