### PR TITLE
Fixing Valhalla api doc location

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ L.Routing.control({
 }).addTo(map);
 ```
 
-See the [Leaflet Routing Machine documentation](http://www.liedman.net/leaflet-routing-machine/tutorials/) and  [Valhalla API documentation](https://github.com/valhalla/valhalla-docs/blob/gh-pages/api-reference.md) for more information.
+See the [Leaflet Routing Machine documentation](http://www.liedman.net/leaflet-routing-machine/tutorials/) and  [Valhalla API documentation](https://github.com/valhalla/valhalla-docs/blob/master/api-reference.md) for more information.
 
 
 If you want to include additional costing options to help define the the route and estimated time along the path, you can pass costing option object as one of router parameter. See the [Valhalla API documentation](https://github.com/valhalla/demos/blob/master/docs/valhalla_service.md#costing-options) for more information on the available options for each routing mode.


### PR DESCRIPTION
* link was sending users to `gh-pages` branch instead of `master`